### PR TITLE
push quietly to prevent token logging

### DIFF
--- a/src/jobs/build_deploy.yml
+++ b/src/jobs/build_deploy.yml
@@ -117,8 +117,9 @@ steps:
     - deploy:
           name: Push to WPE environment
           command: |
-              git push wpe  ${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}
-              git push wpe :${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}
+              # Push quietly to prevent showing the token in log
+              git push -q wpe  ${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}
+              git push -q wpe :${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}
 
     - when:
           condition: << parameters.rollbar_token >>


### PR DESCRIPTION
Update `git push` to `git push -q` to prevent logging the github personal access token in CircleCI logs

See https://stackoverflow.com/a/48753997/3281978 for reference