### PR TITLE
Add new deploy_fury command

### DIFF
--- a/src/examples/wordpress-plugin.yml
+++ b/src/examples/wordpress-plugin.yml
@@ -1,6 +1,7 @@
 description: |
     A sample CircleCI config file that uses the ryanshoover/wpengine orb
-    to run lint and codeception on a WordPress plugin
+    to run lint and codeception on a WordPress plugin. It also deploys tags to
+    a Gemfury repository.
 
 usage:
     version: 2.1
@@ -11,9 +12,18 @@ usage:
     workflows:
         version: 2
 
-        test:
+        test-deploy:
             jobs:
                 - wpengine/lint
                 - wpengine/packageCodeception:
                     package_type: plugin
                     package_name: my-custom-plugin
+                - wpengine/deploy_fury:
+                    requires:
+                        - wpengine/lint
+                        - wpengine/packageCodeception
+                    filters:
+                        tags:
+                            only: /^\d+\.\d+\.\d+$/
+                        branches:
+                            ignore: /.*/

--- a/src/executors/curl.yml
+++ b/src/executors/curl.yml
@@ -1,0 +1,2 @@
+docker:
+    - image: circleci/buildpack-deps:stable-curl

--- a/src/jobs/deploy_fury.yml
+++ b/src/jobs/deploy_fury.yml
@@ -1,0 +1,30 @@
+description: |
+    Deploy a PHP, Node, or Ruby package to a Gemfury repository. Designed to be run on new GitHub releases.
+
+executor: curl
+
+parameters:
+    user:
+        description: Gemfury user or team name
+        type: env_var_name
+        default: GEMFURY_USER
+    token:
+        description: Gemfury PUSH token
+        type: env_var_name
+        default: GEMFURY_TOKEN
+    project:
+        description: Project name
+        type: env_var_name
+        default: CIRCLE_PROJECT_REPONAME
+
+steps:
+    - checkout
+    - run:
+        name: Add Fury git repo
+        command: git remote add fury https://<< parameters.user >>:<< parameters.token >>@git.fury.io/<< parameters.user >>/<< parameters.project >>.git
+    - run:
+        name: Check out master branch
+        command: git checkout master
+    - deploy:
+        name: Deploy to GemFury
+        command: git push fury master --tags

--- a/src/jobs/deploy_fury.yml
+++ b/src/jobs/deploy_fury.yml
@@ -11,7 +11,7 @@ parameters:
     token:
         description: Gemfury PUSH token
         type: env_var_name
-        default: GEMFURY_TOKEN
+        default: GEMFURY_TOKEN_PUSH
     project:
         description: Project name
         type: env_var_name


### PR DESCRIPTION
Adds a new command to the orb.

`deploy_fury` will deploy any package to a Gemfury repository.

```yaml
# Job example
- wpengine/deploy_fury:
  filters:
    tags:
      only: /^\d+\.\d+\.\d+$/
    branches:
      ignore: /.*/
```

```bash
GEMFURY_USER=yourGemfuryUsername
GEMFURY_TOKEN_PUSH=yourGemfuryPushToken
```