### PR TITLE
When building plugins, test for src directory before building

### DIFF
--- a/src/jobs/build_deploy.yml
+++ b/src/jobs/build_deploy.yml
@@ -35,7 +35,7 @@ steps:
           command: |
               for PACKAGE_DIR in $(find . -regextype awk -regex "\./wp-content/(mu-plugins|plugins|themes)/(studiopress|wpengine)-[^/]*/package.json" | sed "s|/[^/]*$||")
               do
-                  if yarn --cwd "$PACKAGE_DIR" run --non-interactive | grep -qe "- build"
+                  if [ -d $PACKAGE_DIR/src && yarn --cwd "$PACKAGE_DIR" run --non-interactive | grep -qe "- build" ]
                   then
                       echo Building in "$PACKAGE_DIR"
                       yarn --cwd "$PACKAGE_DIR" run build

--- a/src/jobs/build_deploy.yml
+++ b/src/jobs/build_deploy.yml
@@ -35,7 +35,7 @@ steps:
           command: |
               for PACKAGE_DIR in $(find . -regextype awk -regex "\./wp-content/(mu-plugins|plugins|themes)/(studiopress|wpengine)-[^/]*/package.json" | sed "s|/[^/]*$||")
               do
-                  if [ -d $PACKAGE_DIR/src && $( yarn --cwd "$PACKAGE_DIR" run --non-interactive | grep -qe "- build" ) ]
+                  if [ -d "$PACKAGE_DIR/src" ] && yarn --cwd "$PACKAGE_DIR" run --non-interactive | grep -qe "- build"
                   then
                       echo Building in "$PACKAGE_DIR"
                       yarn --cwd "$PACKAGE_DIR" run build

--- a/src/jobs/build_deploy.yml
+++ b/src/jobs/build_deploy.yml
@@ -35,7 +35,7 @@ steps:
           command: |
               for PACKAGE_DIR in $(find . -regextype awk -regex "\./wp-content/(mu-plugins|plugins|themes)/(studiopress|wpengine)-[^/]*/package.json" | sed "s|/[^/]*$||")
               do
-                  if [ -d $PACKAGE_DIR/src && yarn --cwd "$PACKAGE_DIR" run --non-interactive | grep -qe "- build" ]
+                  if [ -d $PACKAGE_DIR/src && $( yarn --cwd "$PACKAGE_DIR" run --non-interactive | grep -qe "- build" ) ]
                   then
                       echo Building in "$PACKAGE_DIR"
                       yarn --cwd "$PACKAGE_DIR" run build


### PR DESCRIPTION
Patch for cases where a plugin has a build command in its package.json, but the src files to build aren't present.