### PR TITLE
Require wp-cli-bundle for full suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ workflows:
                   add-pr-comment: true
                   bot-token-variable: GITHUB_TOKEN
                   bot-user: ryanshoover
+                  perform-branch-check: false
                   filters:
                       branches:
                           ignore: /.*/

--- a/src/jobs/codeception.yml
+++ b/src/jobs/codeception.yml
@@ -73,7 +73,7 @@ steps:
                 codeception/util-universalframework \
                 league/factory-muffin \
                 league/factory-muffin-faker \
-                wp-cli/wp-cli
+                wp-cli/wp-cli-bundle
 
     - save_cache:
           key: installwpbrowser-{{ .Environment.CACHE_VERSION }}


### PR DESCRIPTION
Codeception job requires the full `wp-cli/wp-cli-bundle` rather than just `wp-cli/wp-cli`