### PR TITLE
Add job to run dxt-backup

### DIFF
--- a/src/examples/wordpress-site.yml
+++ b/src/examples/wordpress-site.yml
@@ -53,7 +53,7 @@ usage:
                       requires:
                           - wpengine/lint
                           - wpengine/codeception
-                          - wpengine/backup_prod
+                          - wpengine/backup
                       filters:
                           branches:
                               only:

--- a/src/examples/wordpress-site.yml
+++ b/src/examples/wordpress-site.yml
@@ -53,6 +53,7 @@ usage:
                       requires:
                           - wpengine/lint
                           - wpengine/codeception
+                          - wpengine/backup_prod
                       filters:
                           branches:
                               only:

--- a/src/jobs/backup.yml
+++ b/src/jobs/backup.yml
@@ -1,0 +1,14 @@
+description: |
+    Generate a backup of production on deployment to staging.
+    `yarn run dxt-backup` 
+
+executor: php
+
+steps:
+    - attach_workspace:
+          at: /home/circleci/project
+
+    - run:
+          name: Run the backup script.
+          command: |
+              yarn run dxt-backup

--- a/src/jobs/backup.yml
+++ b/src/jobs/backup.yml
@@ -1,5 +1,5 @@
 description: |
-    Generate a backup of production on deployment to staging.
+    Generate a backup of production prior to deployment.
     `yarn run dxt-backup` 
 
 executor: php


### PR DESCRIPTION
Add's a job to run the dxt-backup command. 

.circleci/config.yml on each site needs to get updated to run - wpengine/backup on the Staging pull
Each site package.json needs  "@dxt/backup": "https://github.com/jayhill90/dxt-backup"` as a dependency added.

