### PR TITLE
Add ability to deploy to any install

### DIFF
--- a/src/commands/find_wpe_install.yml
+++ b/src/commands/find_wpe_install.yml
@@ -21,6 +21,7 @@ steps:
                   WPE_ENV="<< parameters.environment >>"
               fi
 
+              # Set the destination according to the environment.
               case "$WPE_ENV" in
                   master)
                       WPE_INSTALL="$WPE_PRODUCTION_INSTALL";;
@@ -31,6 +32,11 @@ steps:
                   *)
                       WPE_INSTALL="$WPE_DEVELOPMENT_INSTALL";;
               esac
+
+              # Match any deploy-install pattern and set the install as the destination.
+              if [[ "$CIRCLE_BRANCH" =~ deploy-[a-z][a-z0-9]{2,13} ]]; then
+                  WPE_INSTALL="${CIRCLE_BRANCH/deploy-/}"
+              fi
 
               echo "export WPE_INSTALL=$WPE_INSTALL" >> "$BASH_ENV"
               source "$BASH_ENV"

--- a/src/examples/wordpress-site.yml
+++ b/src/examples/wordpress-site.yml
@@ -71,6 +71,16 @@ usage:
                               only:
                                   - /feat-.*/
 
+                - wpengine/deploy_site:
+                      name: deploy-site
+                      requires:
+                          - wpengine/lint
+                          - wpengine/codeception
+                      filters:
+                          branches:
+                              only:
+                                  - /deploy-.*/
+
         regression:
             jobs:
                 - wpengine/backstop_reference:


### PR DESCRIPTION
Adds a feature to run the `deploy_site` job to deploy to any install.

If you push up a branch named `deploy-mywpeinstall`, then it will deploy to the `mywpeinstall` install.

Also updates the site example to include an example usage.

To test:

1. Use any site that's set up to deploy with CircleCI
2. Edit the `.circleci/config.yml` file
3. Check out a new branch called `deploy-nameofyourtestinstall`
4. Change the orb inclusion at the top to be `wpengine: ryanshoover/wpengine@dev:367496c`
5. Add this blob to the bottom of the `build_test_deploy` workflow
    ```
                - wpengine/deploy_site:
                      name: deploy-site
                      environment: qa-site
                      requires:
                          - wpengine/lint
                          - wpengine/codeception
                      filters:
                          branches:
                              only:
                                  - /deploy-.*/
    ```
6. Push your branch to github
7. You should see the branch deploy to your install