### PR TITLE
Add the -c flag to account for a breaking change in git 2.32.0

### DIFF
--- a/src/commands/gitignoreswap.yml
+++ b/src/commands/gitignoreswap.yml
@@ -27,7 +27,7 @@ steps:
           command: git add .
     - run:
           name: After adding all files, remove files that should be ignored
-          command: git ls-files -z --ignored --exclude-standard | xargs -0 git rm -r --force --ignore-unmatch --cached
+          command: git ls-files -c -z --ignored --exclude-standard | xargs -0 git rm -r --force --ignore-unmatch --cached
     - run:
           name: Commit build files
           command: git commit -m "Deployment commit"


### PR DESCRIPTION
In git 2.32.0, a breaking change appears to have been introduced: https://github.com/git/git/blob/master/builtin/ls-files.c#L753:L756

We will need to include the `-c` flag in the orb to replicate historic behavior: https://github.com/ryanshoover/orb-wpengine-deploy/blob/master/src/commands/gitignoreswap.yml#L30