### PR TITLE
Add's lib2apache-mod-php and php-mysql for apache usage

### DIFF
--- a/src/jobs/codeception.yml
+++ b/src/jobs/codeception.yml
@@ -50,6 +50,8 @@ steps:
             sudo apt-get update && \
             sudo apt-get -y install \
                 apache2 \
+                libapache2-mod-php \
+                php-mysql \
                 default-mysql-client \
                 libjpeg-dev \
                 libpng-dev \


### PR DESCRIPTION
Apache got borked somehow and this adds lib2apache-mod-php and php-mysql so PHP and MySQL connections work.

![](https://slack-imgs.com/?c=1&o1=ro&url=https%3A%2F%2Fmedia4.giphy.com%2Fmedia%2FggboqWTfYfIjZXO9nO%2Fgiphy.gif%3Fcid%3D6104955e97a8c69dc73fad3d3fd05907d021c89ed8ad08ba%26rid%3Dgiphy.gif%26ct%3Dg)