### PR TITLE
Require older versions of codeception modules until wpbrowser is compatible

### DIFF
--- a/src/jobs/codeception.yml
+++ b/src/jobs/codeception.yml
@@ -64,13 +64,13 @@ steps:
           command: |
             composer global require --optimize-autoloader \
                 lucatume/wp-browser \
-                codeception/module-asserts \
-                codeception/module-cli \
-                codeception/module-db \
-                codeception/module-filesystem \
-                codeception/module-phpbrowser \
-                codeception/module-rest \
-                codeception/module-webdriver \
+                codeception/module-asserts:^1.0 \
+                codeception/module-cli:^1.0 \
+                codeception/module-db:^1.0 \
+                codeception/module-filesystem:^1.0 \
+                codeception/module-phpbrowser:^1.0 \
+                codeception/module-rest:^1.0 \
+                codeception/module-webdriver:^1.0 \
                 codeception/util-universalframework \
                 league/factory-muffin \
                 league/factory-muffin-faker \


### PR DESCRIPTION
[WEB-5163](https://wpengine.atlassian.net/browse/WEB-5163)

Force older versions of Codeception modules until lucatume/wp-browser#549 is resolved.
